### PR TITLE
Disable Paradox Github integration

### DIFF
--- a/init.el
+++ b/init.el
@@ -92,7 +92,9 @@
 
 (use-package paradox
   :ensure
-  :bind (("C-x p" . paradox-upgrade-packages)))
+  :bind (("C-x p" . paradox-upgrade-packages))
+  :config
+  (setq paradox-github-token t))
 
 (use-package mwim
   :ensure


### PR DESCRIPTION
The Github integration requires a token for starring the Github repositories of used packages