### PR TITLE
Remove the Python version from mode-line

### DIFF
--- a/lisp/config-looks.el
+++ b/lisp/config-looks.el
@@ -29,7 +29,9 @@
 
 (use-package doom-modeline
   :ensure
-  :config (doom-modeline-init))
+  :config
+  (doom-modeline-init)
+  (setq doom-modeline-python-executable nil))
 
 (use-package mode-icons
   :if window-system


### PR DESCRIPTION
The version shown reflects the version of the system Python. It does not change when pyvenv or pipenv is activated.