### PR TITLE
Persistent minibuffer history

### DIFF
--- a/init.el
+++ b/init.el
@@ -109,9 +109,6 @@
 
 (fset #'yes-or-no-p #'y-or-n-p)
 
-(use-package savehist
-  :init (savehist-mode 1))
-
 (remove-hook 'kill-buffer-query-functions #'process-kill-buffer-query-function)
 
 (defun display-startup-echo-area-message () ".")
@@ -1045,5 +1042,8 @@ _M-p_: Unmark  _M-n_: Unmark  _q_: Quit"
 (use-package powershell
   :ensure
   :defer)
+
+(use-package savehist
+  :init (savehist-mode 1))
 
 ;;; init.el ends here

--- a/init.el
+++ b/init.el
@@ -1044,6 +1044,6 @@ _M-p_: Unmark  _M-n_: Unmark  _q_: Quit"
   :defer)
 
 (use-package savehist
-  :init (savehist-mode 1))
+  :config (savehist-mode 1))
 
 ;;; init.el ends here

--- a/init.el
+++ b/init.el
@@ -109,6 +109,9 @@
 
 (fset #'yes-or-no-p #'y-or-n-p)
 
+(use-package savehist
+  :init (savehist-mode 1))
+
 (remove-hook 'kill-buffer-query-functions #'process-kill-buffer-query-function)
 
 (defun display-startup-echo-area-message () ".")


### PR DESCRIPTION
https://oremacs.com/2019/07/09/ivy-reverse-i-search/

Saving the minibuffer history across sessions helps us utilize ivy-reverse-i-search better