### PR TITLE
Allow user config in ~/.emacs.site.d/{init,config}.el loaded before/after config, respectively

### DIFF
--- a/init.el
+++ b/init.el
@@ -42,12 +42,12 @@
 
 (defcustom my/font-family (seq-find (lambda (font) (find-font (font-spec :name font)))
                                     '("Iosevka SS05" "Iosevka SS09" "Iosevka SS01" "Iosevka" "Ubuntu Mono"))
-  "Emacs font."
+  "Emacs font family."
   :type 'string
   :group 'my/customizations)
 
 (defcustom my/font-height (if (eq system-type 'darwin) 150 120)
-  "Emacs font."
+  "Emacs font height."
   :type 'string
   :group 'my/customizations)
 

--- a/init.el
+++ b/init.el
@@ -31,10 +31,6 @@
   (require 'use-package)
   (require 'bind-key))
 
-(push "~/.emacs.d/lisp" load-path)
-
-(require 'config-defuns-autoloads)
-
 (defgroup my/customizations nil
   "Customizations"
   :group 'convenience)
@@ -42,6 +38,17 @@
 (defcustom my/theme 'doom-one
   "Emacs theme."
   :type 'symbol
+  :group 'my/customizations)
+
+(defcustom my/font-family (seq-find (lambda (font) (find-font (font-spec :name font)))
+                                    '("Iosevka SS05" "Iosevka SS09" "Iosevka SS01" "Iosevka" "Ubuntu Mono"))
+  "Emacs font."
+  :type 'string
+  :group 'my/customizations)
+
+(defcustom my/font-height (if (eq system-type 'darwin) 150 120)
+  "Emacs font."
+  :type 'string
   :group 'my/customizations)
 
 (defcustom my/windmove-modifier "M"
@@ -54,6 +61,13 @@
   :type 'boolean
   :group 'my/customizations)
 (make-variable-buffer-local 'my/disable-clang-format-on-save)
+
+(if (file-exists-p "~/.emacs.site.d/init.el")
+    (load "~/.emacs.site.d/init.el"))
+
+(push "~/.emacs.d/lisp" load-path)
+
+(require 'config-defuns-autoloads)
 
 (bind-key "<escape>" #'keyboard-escape-quit)
 (bind-key "C-x r q" #'save-buffers-kill-emacs)
@@ -1050,5 +1064,8 @@ _M-p_: Unmark  _M-n_: Unmark  _q_: Quit"
 
 (use-package savehist
   :config (savehist-mode 1))
+
+(if (file-exists-p "~/.emacs.site.d/config.el")
+    (load "~/.emacs.site.d/config.el"))
 
 ;;; init.el ends here

--- a/init.el
+++ b/init.el
@@ -48,7 +48,7 @@
 
 (defcustom my/font-height (if (eq system-type 'darwin) 150 120)
   "Emacs font height."
-  :type 'string
+  :type 'integer
   :group 'my/customizations)
 
 (defcustom my/windmove-modifier "M"

--- a/lisp/config-looks.el
+++ b/lisp/config-looks.el
@@ -9,18 +9,14 @@
 
 (setq frame-title-format '("" invocation-name ": %b"))
 
-(use-package cus-edit
-  :config
-  (when (eq (custom-face-state 'default) 'standard)
-        (custom-set-faces
-         `(default
-            ((t
-              :family ,(seq-find (lambda (font) (find-font (font-spec :name font)))
-                                 '("Iosevka SS05" "Iosevka SS09" "Iosevka SS01" "Iosevka" "Ubuntu Mono"))
-              :height ,(if (eq system-type 'darwin) 150 120)))))))
-
 (eval-when-compile
-  (defvar my/theme))
+  (defvar my/theme)
+  (defvar my/font-family)
+  (defvar my/font-height))
+
+(set-face-attribute 'default nil
+                    :family my/font-family
+                    :height my/font-height)
 
 (use-package doom-themes
   :ensure
@@ -35,9 +31,7 @@
 
 (use-package doom-modeline
   :ensure
-  :config
-  (setq doom-modeline-python-executable nil)
-  (doom-modeline-mode 1))
+  :config (doom-modeline-mode 1))
 
 (when window-system
   (scroll-bar-mode -1)


### PR DESCRIPTION
This adds:

- `~/.emacs.site.d/init.el` which is loaded *before* any of our configuration so that the user can set default for things such as theme and font.
- `~/.emacs.site.d/config.el` which is loaded *after* all of our configuration so that the user can override or use anything we define.

These were inspired by spacemacs' init/config.

@r-darwish, @vmalloc what do you think?