### PR TITLE
Lower split-width-threshold

### DIFF
--- a/init.el
+++ b/init.el
@@ -151,8 +151,12 @@
       scroll-margin 5
       scroll-preserve-screen-position t
       visual-order-cursor-movement t
-      split-width-threshold 120
+
       )
+
+(use-package window
+  :defer
+  :init (setq split-width-threshold 120))
 
 (if (eq system-type 'windows-nt)
     (progn

--- a/init.el
+++ b/init.el
@@ -150,8 +150,8 @@
       scroll-conservatively 10000
       scroll-margin 5
       scroll-preserve-screen-position t
-      visual-order-cursor-movement t
       split-width-threshold 120
+      visual-order-cursor-movement t
       )
 
 (if (eq system-type 'windows-nt)

--- a/init.el
+++ b/init.el
@@ -151,6 +151,7 @@
       scroll-margin 5
       scroll-preserve-screen-position t
       visual-order-cursor-movement t
+      split-width-threshold 120
       )
 
 (if (eq system-type 'windows-nt)

--- a/init.el
+++ b/init.el
@@ -151,12 +151,8 @@
       scroll-margin 5
       scroll-preserve-screen-position t
       visual-order-cursor-movement t
-
+      split-width-threshold 120
       )
-
-(use-package window
-  :defer
-  :init (setq split-width-threshold 120))
 
 (if (eq system-type 'windows-nt)
     (progn


### PR DESCRIPTION
This will cause Emacs to split horizontally on 13" laptop screen.

For some reason use-package doesn't work well with the built-in window package, so I just made this as a setq