### PR TITLE
Enable rainbow-mode only in CSS related modes

### DIFF
--- a/init.el
+++ b/init.el
@@ -938,7 +938,7 @@ _M-p_: Unmark  _M-n_: Unmark  _q_: Quit"
 
 (use-package rainbow-mode
   :ensure
-  :hook (prog-mode . rainbow-mode)
+  :hook ((css-mode scss-mode) . rainbow-mode)
   :config (setq rainbow-x-colors nil))
 
 (use-package restclient


### PR DESCRIPTION
Enabling rainbow-mode in prog-mode is problematic since it colors words following hash (#) which is
commonly used to mark comments and also in e.g. ember where a loop is #each.