### PR TITLE
Remove workaround for Emacs TLS bug (fix #86)

### DIFF
--- a/init.el
+++ b/init.el
@@ -11,9 +11,6 @@
 (defconst my/cargo-check-flags "--all-features --tests --examples")
 (defconst my/cargo-build-flags "--all-features")
 
-(eval-when-compile
-  (defvar gnutls-algorithm-priority))
-
 (setq gc-cons-threshold (* 100 1024 1024)
       file-name-handler-alist nil
       inhibit-message t
@@ -131,8 +128,7 @@
       (eval-when-compile (defvar w32-lwindow-modifier))
       (setq w32-lwindow-modifier 'super)
       (w32-register-hot-key [s-s]))
-  (setq shell-file-name "/bin/sh"
-        gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3"))
+  (setq shell-file-name "/bin/sh"))
 
 (setq-default comment-column 0
               fill-column 100


### PR DESCRIPTION
Merge when Emacs 26.3 is added to all of these: 

- [x] [Arch Linux](https://www.archlinux.org/packages/extra/x86_64/emacs/)
- [x] [Scoop](https://github.com/lukesampson/scoop-extras/blob/master/bucket/emacs.json)
- [x] [Homebrew](https://formulae.brew.sh/formula/emacs)