### PR TITLE
Disable LSP ui doc by default

### DIFF
--- a/init.el
+++ b/init.el
@@ -553,11 +553,13 @@
               ("C-c l r" . lsp-rename)
               ("C-c l c" . lsp-ui-sideline-apply-code-actions)
               ("C-c l s" . lsp-ui-find-workspace-symbol)
+              ("C-c l d" . lsp-ui-doc-mode)
               ([remap xref-find-definitions] . lsp-ui-peek-find-definitions)
               ([remap xref-find-references] . lsp-ui-peek-find-references))
   :config
   (setq lsp-ui-sideline-ignore-duplicate t
-                lsp-ui-sideline-show-hover nil)
+        lsp-ui-doc-enable nil
+        lsp-ui-sideline-show-hover nil)
   (set-face-attribute 'lsp-ui-sideline-code-action nil :foreground (doom-color 'cyan))
   )
 


### PR DESCRIPTION
This mode can be quite intrusive when working either on a laptop screen or looking at functions with
large documentation block. I think it's best to be set off by default.