### PR TITLE
Fix LSP Java loading

### DIFF
--- a/init.el
+++ b/init.el
@@ -507,6 +507,7 @@
 
 (use-package lsp-java
   :ensure
+  :demand
   :bind (:map java-mode-map
               ("C-c l i" . lsp-java-add-import)
               ("C-c l o" . lsp-java-organize-imports))


### PR DESCRIPTION
When LSP Java is deferred there is nothing that can cause it to auto-load. Since it's an extension
to LSP, it makes sense to load it immediately after LSP is loaded